### PR TITLE
Automatically filter secondary alignments from user-generated BAMs

### DIFF
--- a/hapog/mapping.py
+++ b/hapog/mapping.py
@@ -5,7 +5,6 @@ import warnings
 
 
 def launch_PE_mapping(genome, pe1, pe2, threads, samtools_memory):
-    ########## BWA INDEX ##########
     print("\nGenerating bwa index...", flush=True)
     cmd = ["bwa", "index", genome]
 
@@ -29,7 +28,6 @@ def launch_PE_mapping(genome, pe1, pe2, threads, samtools_memory):
 
     print(f"Done in {int(time.perf_counter() - start)} seconds", flush=True)
 
-    ########## BWA MEM ##########
     print("\nLaunching mapping on genome...", flush=True)
     cmd = "bash -c 'bwa mem -t %s %s " % (threads, genome)
 
@@ -64,7 +62,6 @@ def launch_PE_mapping(genome, pe1, pe2, threads, samtools_memory):
     else:
         print(f"Done in {int(time.perf_counter() - start)} seconds", flush=True)
 
-    ########## SAMTOOLS INDEX ##########
     index_bam()
 
 
@@ -86,13 +83,12 @@ def launch_LR_mapping(genome, long_reads, threads, samtools_memory):
     else:
         print(f"Done in {int(time.perf_counter() - start)} seconds", flush=True)
 
-    ########## SAMTOOLS INDEX ##########
     index_bam()
 
 
 def remove_secondary_alignments(bam, output_dir):
     print("\nRemoving secondary alignments from BAM file...", flush=True)
-    cmd = ["samtools", "view", "-h", "-F", "0x900", bam]
+    cmd = ["samtools", "view", "-b", "-h", "-F", "0x900", bam]
 
     start = time.perf_counter()
     with open(f"{output_dir}/cmds/samtools_view.cmds", "w") as cmd_file:

--- a/hapog/mapping.py
+++ b/hapog/mapping.py
@@ -17,7 +17,7 @@ def launch_PE_mapping(genome, pe1, pe2, threads, samtools_memory):
             warnings.simplefilter("ignore")
             _ = subprocess.run(
                 cmd,
-                stdout=open("logs/baw_index.o", "w"),
+                stdout=open("logs/bwa_index.o", "w"),
                 stderr=open("logs/bwa_index.e", "w"),
                 check=True,
             )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]	
-version = "1.3.6"
+version = "1.3.8"

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(this_directory, "README.md")) as f:
 setup(
     name="hapog",
     packages=["hapog"],
-    version="1.3.6",
+    version="1.3.8",
     license="CeCILL",
     description="Haplotype-Aware Polishing of Genomes",
     long_description=long_description,
@@ -37,7 +37,7 @@ setup(
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
         "License :: OSI Approved :: CEA CNRS Inria Logiciel Libre License, version 2.1 (CeCILL-2.1)",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     entry_points={"console_scripts" : ["hapog = hapog.cli:main"]},
     cmdclass={"build": BuildCommand},


### PR DESCRIPTION
Secondary alignments do not contain sequences in the BAM record. This PR will automatically filter secondary alignments from user-generated BAMs to prevent issues like #26 